### PR TITLE
Release of version 1.0.5

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 6.2.6
+  bundleVersion: 1.0.5
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/npm/getBinary.js
+++ b/npm/getBinary.js
@@ -9,7 +9,7 @@ function getBinary(){
 
     if (type !== 'Windows_NT') throw new Error(`Unsupported platform: Currently only for Windows`);
 
-    return new Binary("dcl-edit.exe",`https://github.com/metagamehub/dcl-edit/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
+    return new Binary("dcl-edit.exe",`https://github.com/cblech/dcl-edit-automation/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
 }
 
 module.exports = getBinary;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "6.2.6",
+  "version": "1.0.5",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
To test this version, run: 
`npm install https://gitpkg.now.sh/{{ env.DCL_EDIT_REPO }}/npm?ref/feautre/release_version_{{ github.event.inputs.version }} -g` 

You still need to `npm publish` and merge this PR