### PR TITLE
Release of version 1.0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Build Windows
         shell: cmd
         run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe"
-          -projectPath ${{ github.workspace }}
-          -batchmode
-          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" \
+          -projectPath ${{ github.workspace }} \
+          -batchmode \
+          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe \
           -quit
           
       - name: Upload a Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
         
-      #- name: Cache Unity files
-      #  uses: actions/cache@v3
-      #  with:
-      #    path: ${{ github.workspace }}\Library
-      #    key: unity-library
-      #    restore-keys: unity-
+      - name: Cache Unity files
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}\Library
+          key: unity-library
+          restore-keys: unity-
       
       - name: Create new branch
         run: |
@@ -31,25 +31,25 @@ jobs:
       - name: Update Version number to ${{ github.event.inputs.version }}
         run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
         
-      - name: Fake build
-        run: |
-          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86 -ItemType Directory
-          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe.txt -Value "I am a Windows executable"
-          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux -ItemType Directory
-          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit.txt -Value "I am a Linux executable"
-          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app -ItemType Directory
-          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app\macapp.txt -Value "I am a Mac executable"
+      #- name: Fake build
+      #  run: |
+      #    New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86 -ItemType Directory
+      #    Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe.txt -Value "I am a Windows executable"
+      #    New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux -ItemType Directory
+      #    Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit.txt -Value "I am a Linux executable"
+      #    New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app -ItemType Directory
+      #    Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app\macapp.txt -Value "I am a Mac executable"
         
-      #- name: Build All
-      #  shell: cmd
-      #  run: >
-      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
-      #    -projectPath ${{ github.workspace }} 
-      #    -batchmode 
-      #    -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe 
-      #    -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit
-      #    -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
-      #    -quit
+      - name: Build All
+        shell: cmd
+        run: >
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+          -projectPath ${{ github.workspace }} 
+          -batchmode 
+          -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe 
+          -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit
+          -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
+          -quit
           
       #- name: Build Windows
       #  shell: cmd
@@ -121,13 +121,13 @@ jobs:
           --title "Release of version ${{ github.event.inputs.version }}"
           --body "this is some cool description for this pull request"
         
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          # Artifact name
-          name: Some build # optional, default is artifact
-          # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}\Build
+      #- name: Upload a Build Artifact
+      #  uses: actions/upload-artifact@v3.1.2
+      #  with:
+      #    # Artifact name
+      #    name: Some build # optional, default is artifact
+      #    # A file, directory or wildcard pattern that describes what to upload
+      #    path: ${{ github.workspace }}\Build
           
 
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,9 @@ jobs:
           name: "Release ${{ github.event.inputs.version }}"
           body: "This is a very cool Release (Version: ${{ github.event.inputs.version }})"
           files: |
-            Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
-            Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
-            Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
+            Build/dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
+            Build/dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
+            Build/dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
           fail_on_unmatched_files: true
           draft: true
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
         
       #- name: Cache Unity files
       #  uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Update Version number to ${{ github.event.inputs.version }}
         run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
         
+      - name: Commit and push version number update
+        run: |
+          git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
+          git push
+   
       - name: Fake build
         run: |
           New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86 -ItemType Directory
@@ -81,7 +86,8 @@ jobs:
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar -mx=9
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar -mx=9
-          
+      
+           
       - name: "Create tag"
         run: |
           git tag ${{ github.event.inputs.version }}
@@ -97,6 +103,7 @@ jobs:
             ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
             ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
             ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
+          fail_on_unmatched_files: true
           draft: true
           token: ${{ secrets.GH_TOKEN }}
       
@@ -108,10 +115,5 @@ jobs:
           # A file, directory or wildcard pattern that describes what to upload
           path: ${{ github.workspace }}\Build
           
-      - name: Commit and push version number update
-        run: |
-          git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
-          git push
 
-          
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
           key: unity-library
           restore-keys: unity-
       
-      #- name: Update Version number to ${{ github.event.inputs.version }}
-      #  shell: pwsh
-      #  run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
+      - name: Update Version number to ${{ github.event.inputs.version }}
+        shell: pwsh
+        run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
         
       - name: Fake build
         run: |
@@ -79,6 +79,11 @@ jobs:
           name: Some build # optional, default is artifact
           # A file, directory or wildcard pattern that describes what to upload
           path: ${{ github.workspace }}\Build
+          
+      - name: Commit and push version number update
+        run: |
+          git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
+          git push
 
           
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
         
-      - name: Cache Unity files
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}\Library
-          key: unity-library
-          restore-keys: unity-
+      #- name: Cache Unity files
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: ${{ github.workspace }}\Library
+      #    key: unity-library
+      #    restore-keys: unity-
       
       - name: Update Version number to ${{ github.event.inputs.version }}
         run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
           start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
           -projectPath ${{ github.workspace }} 
           -batchmode 
-          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe 
+          -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-version-windows-x86\dcl-edit.exe 
+          -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-version-linux\dcl-edit
+          -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-version-macos.app
           -quit
           
       - name: Upload a Build Artifact
@@ -30,7 +32,7 @@ jobs:
           # Artifact name
           name: Some build # optional, default is artifact
           # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}\Build\testbuild.exe
+          path: ${{ github.workspace }}\Build
 
           
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build dcl-edit
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push]
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: "The version number of the build. Format `major.minor.patch`. E.g.: `2.1.24`"
+    
 jobs:
   build-dcl-edit:
     runs-on: self-hosted
@@ -15,32 +21,44 @@ jobs:
           key: unity-library
           restore-keys: unity-
           
-      - name: Build Windows
+          
+      - name: Build All
         shell: cmd
         run: >
           start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
           -projectPath ${{ github.workspace }} 
           -batchmode 
-          -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-version-windows-x86\dcl-edit.exe 
+          -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe 
+          -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit
+          -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
           -quit
           
-      - name: Build Linux
-        shell: cmd
-        run: >
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
-          -projectPath ${{ github.workspace }} 
-          -batchmode 
-          -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-version-linux\dcl-edit
-          -quit
-          
-      - name: Build Mac
-        shell: cmd 
-        run: >
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
-          -projectPath ${{ github.workspace }} 
-          -batchmode 
-          -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-version-macos.app
-          -quit
+      #- name: Build Windows
+      #  shell: cmd
+      #  run: >
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+      #    -projectPath ${{ github.workspace }} 
+      #    -batchmode 
+      #    -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-version-windows-x86\dcl-edit.exe 
+      #    -quit
+      #    
+      #- name: Build Linux
+      #  shell: cmd
+      #  run: >
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+      #    -projectPath ${{ github.workspace }} 
+      #    -batchmode 
+      #    -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-version-linux\dcl-edit
+      #    -quit
+      #    
+      #- name: Build Mac
+      #  shell: cmd 
+      #  run: >
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+      #    -projectPath ${{ github.workspace }} 
+      #    -batchmode 
+      #    -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-version-macos.app
+      #    -quit
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
           branch: ref/feautre/release_version_${{ github.event.inputs.version }}
           base: Refactoring
           body: this is some cool description for this pull request
+          token: ${{ secrets.GH_TOKEN }}
       
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,9 @@ jobs:
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar -mx=9
           
       - name: "Create tag"
-        uses: rickstaa/action-create-tag@v1
-        with:
-          tag: "${{ github.event.inputs.version }}"
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push --tags
           
       - name: GH Release
         uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,11 @@ jobs:
         run: |
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar -mx=9
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar -mx=9
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar -mx=9
+          
           
       #- name: GH Release
       #  uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,9 @@ jobs:
           name: "Release ${{ github.event.inputs.version }}"
           body: "This is a very cool Release (Version: ${{ github.event.inputs.version }})"
           files: |
-            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
-            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
-            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
+            Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
+            Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
+            Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
           fail_on_unmatched_files: true
           draft: true
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,14 +111,16 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       
       - name: create pull request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: Release of version ${{ github.event.inputs.version }}
-          branch: ref/feautre/release_version_${{ github.event.inputs.version }}
-          base: Refactoring
-          body: this is some cool description for this pull request
-          token: ${{ secrets.GH_TOKEN }}
-      
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >
+          gh pr create 
+          --repo cblech/dcl-edit-automation 
+          --base Refactoring 
+          --head ref/feautre/release_version_${{ github.event.inputs.version }} 
+          --title "Release of version ${{ github.event.inputs.version }}"
+          --body "this is some cool description for this pull request"
+        
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
           
       - name: Build Windows
         shell: cmd
-        run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" \
-          -projectPath ${{ github.workspace }} \
-          -batchmode \
-          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe \
+        run: >
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+          -projectPath ${{ github.workspace }} 
+          -batchmode 
+          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe 
           -quit
           
       - name: Upload a Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,23 @@ jobs:
           -projectPath ${{ github.workspace }} 
           -batchmode 
           -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-version-windows-x86\dcl-edit.exe 
+          -quit
+          
+      - name: Build Linux
+        shell: cmd
+        run: >
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+          -projectPath ${{ github.workspace }} 
+          -batchmode 
           -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-version-linux\dcl-edit
+          -quit
+          
+      - name: Build Mac
+        shell: cmd
+        run: >
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+          -projectPath ${{ github.workspace }} 
+          -batchmode 
           -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-version-macos.app
           -quit
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,13 +82,23 @@ jobs:
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar -mx=9
           
+      - name: "Create tag"
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "${{ github.event.inputs.version }}"
           
-      #- name: GH Release
-      #  uses: softprops/action-gh-release@v0.1.15
-      #  with:
-      #    files: |
-      #      Release.txt
-      #      LICENSE
+      - name: GH Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          tag_name: "${{ github.event.inputs.version }}"
+          name: "Release ${{ github.event.inputs.version }}"
+          body: "This is a very cool Release (Version: ${{ github.event.inputs.version }})"
+          files: |
+            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz
+            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
+            ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
+          draft: true
+          token: ${{ secrets.GH_TOKEN }}
       
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Commit and push version number update
         run: |
           git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
-          git push
+          git push origin HEAD
            
       - name: Create tag
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,14 @@ jobs:
       #    key: unity-library
       #    restore-keys: unity-
       
+      - name: Create new branch
+        run: |
+          git branch -c ref/feautre/release_version_${{ github.event.inputs.version }}
+          git checkout ref/feautre/release_version_${{ github.event.inputs.version }}
+      
       - name: Update Version number to ${{ github.event.inputs.version }}
         run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
         
-      - name: Commit and push version number update
-        run: |
-          git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
-          git push
-   
       - name: Fake build
         run: |
           New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86 -ItemType Directory
@@ -87,8 +87,12 @@ jobs:
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
           7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.tar -mx=9
       
+      - name: Commit and push version number update
+        run: |
+          git commit -am "Updated verion number to ${{ github.event.inputs.version }}"
+          git push
            
-      - name: "Create tag"
+      - name: Create tag
         run: |
           git tag ${{ github.event.inputs.version }}
           git push --tags
@@ -104,8 +108,15 @@ jobs:
             Build/dcl-edit-${{ github.event.inputs.version }}-linux.tar.gz
             Build/dcl-edit-${{ github.event.inputs.version }}-macos.tar.gz
           fail_on_unmatched_files: true
-          draft: true
           token: ${{ secrets.GH_TOKEN }}
+      
+      - name: create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Release of version ${{ github.event.inputs.version }}
+          branch: ref/feautre/release_version_${{ github.event.inputs.version }}
+          base: Refactoring
+          body: this is some cool description for this pull request
       
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,19 @@ jobs:
       #    -batchmode 
       #    -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-version-macos.app
       #    -quit
+      
+      - name: Pack builds
+        run: |
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86
+          7z a ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar.gz ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86.tar -mx=9
           
+      #- name: GH Release
+      #  uses: softprops/action-gh-release@v0.1.15
+      #  with:
+      #    files: |
+      #      Release.txt
+      #      LICENSE
+      
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
           restore-keys: unity-
       
       - name: Update Version number to ${{ github.event.inputs.version }}
-        shell: pwsh
         run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
         
       - name: Fake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,18 +20,30 @@ jobs:
           path: ${{ github.workspace }}\Library
           key: unity-library
           restore-keys: unity-
-          
-          
-      - name: Build All
-        shell: cmd
-        run: >
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
-          -projectPath ${{ github.workspace }} 
-          -batchmode 
-          -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe 
-          -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit
-          -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
-          -quit
+      
+      #- name: Update Version number to ${{ github.event.inputs.version }}
+      #  shell: pwsh
+      #  run: C:\Users\Administrator\repos\workflow\changeVersionNumber.ps1 -projectPath ${{ github.workspace }} -version ${{ github.event.inputs.version }}
+        
+      - name: Fake build
+        run: |
+          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86 -ItemType Directory
+          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe.txt -Value "I am a Windows executable"
+          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux -ItemType Directory
+          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit.txt -Value "I am a Linux executable"
+          New-Item -Path ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app -ItemType Directory
+          Set-Content ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app\macapp.txt -Value "I am a Mac executable"
+        
+      #- name: Build All
+      #  shell: cmd
+      #  run: >
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
+      #    -projectPath ${{ github.workspace }} 
+      #    -batchmode 
+      #    -buildWindowsPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-windows-x86\dcl-edit.exe 
+      #    -buildLinux64Player ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-linux\dcl-edit
+      #    -buildOSXUniversalPlayer ${{ github.workspace }}\Build\dcl-edit-${{ github.event.inputs.version }}-macos.app
+      #    -quit
           
       #- name: Build Windows
       #  shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: GitHub Actions Demo
+name: Build dcl-edit
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 on: [push]
 jobs:
-  Explore-GitHub-Actions:
+  build-dcl-edit:
     runs-on: self-hosted
     steps:
       - name: Check out repository code
@@ -18,7 +18,11 @@ jobs:
       - name: Build Windows
         shell: cmd
         run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe"
+          -projectPath ${{ github.workspace }}
+          -batchmode
+          -buildWindowsPlayer ${{ github.workspace }}\dcl-edit-version-windows-x86\dcl-edit.exe
+          -quit
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           -quit
           
       - name: Build Mac
-        shell: cmd
+        shell: cmd 
         run: >
           start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" 
           -projectPath ${{ github.workspace }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Demo
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: self-hosted
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,16 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: self-hosted
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      #- run: echo "🔎 The name of your branch is ${{ github.ref }} and repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v3
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: Build Windows
+        run: |
+          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" |
+          -projectPath ${{ github.workspace }} |
+          -batchmode |
+          -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe |
+          -quit
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,13 @@ jobs:
       - name: Build Windows
         shell: cmd
         run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath C:\Users\Administrator\repos\dcl-edit -batchmode -buildWindowsPlayer C:\Users\Administrator\UnityBuilds\dcl-edit\testbuild.exe -quit
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\testbuild.exe -quit
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          # Artifact name
+          name: Some build # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: ${{ github.workspace }}\..\testbuild.exe
+          
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build Windows
         run: |
-          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" |
-          -projectPath ${{ github.workspace }} |
-          -batchmode |
-          -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe |
+          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" \|
+          -projectPath ${{ github.workspace }} \|
+          -batchmode \|
+          -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe \|
           -quit
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
         run: |
           ls ${{ github.workspace }}
       - name: Build Windows
+        shell: cmd
         run: |
           start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath C:\Users\Administrator\repos\dcl-edit -batchmode -buildWindowsPlayer C:\Users\Administrator\UnityBuilds\dcl-edit\testbuild.exe -quit
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,5 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build Windows
         run: |
-          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" \|
-          -projectPath ${{ github.workspace }} \|
-          -batchmode \|
-          -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe \|
-          -quit
+          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe -quit
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           path: ${{ github.workspace }}\Library
           key: unity-library
-          restore-key: unity-
+          restore-keys: unity-
           
       - name: Build Windows
         shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,5 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build Windows
         run: |
-          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe -quit"
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath C:\Users\Administrator\repos\dcl-edit -batchmode -buildWindowsPlayer C:\Users\Administrator\UnityBuilds\dcl-edit\testbuild.exe -quit
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           path: ${{ github.workspace }}\Library
           key: unity-library
+          restore-key: unity-
           
       - name: Build Windows
         shell: cmd
@@ -26,5 +27,6 @@ jobs:
           name: Some build # optional, default is artifact
           # A file, directory or wildcard pattern that describes what to upload
           path: ${{ github.workspace }}\Build\testbuild.exe
+
           
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,22 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+        
+      - name: Cache Unity files
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}\Library
+          key: unity-library
+          
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}
+          
       - name: Build Windows
         shell: cmd
         run: |
           start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
+          
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Build Windows
         shell: cmd
         run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\testbuild.exe -quit
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
           # Artifact name
           name: Some build # optional, default is artifact
           # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}\..\testbuild.exe
+          path: ${{ github.workspace }}\Build\testbuild.exe
           
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,13 @@ jobs:
           path: ${{ github.workspace }}\Library
           key: unity-library
           
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
+      - name: Make Library folder
+        run: mkdir Library; echo foo | Out-File Library/foo.txt
           
-      - name: Build Windows
-        shell: cmd
-        run: |
-          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
+      #- name: Build Windows
+      #  shell: cmd
+      #  run: |
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,6 @@ jobs:
           path: ${{ github.workspace }}\Library
           key: unity-library
           
-      #- name: Make Library folder
-      #  run: mkdir Library; echo foo | Out-File Library/foo.txt
-          
       - name: Build Windows
         shell: cmd
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and repository is ${{ github.repository }}."
+      #- run: echo "🔎 The name of your branch is ${{ github.ref }} and repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,13 @@ jobs:
           path: ${{ github.workspace }}\Library
           key: unity-library
           
-      - name: Make Library folder
-        run: mkdir Library; echo foo | Out-File Library/foo.txt
+      #- name: Make Library folder
+      #  run: mkdir Library; echo foo | Out-File Library/foo.txt
           
-      #- name: Build Windows
-      #  shell: cmd
-      #  run: |
-      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
+      - name: Build Windows
+        shell: cmd
+        run: |
+          start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
           
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,5 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build Windows
         run: |
-          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe -quit
+          "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\..\..\UnityBuilds\dcl-edit\dcl-edit.exe -quit"
           

--- a/.github/workflows/testAction.yml
+++ b/.github/workflows/testAction.yml
@@ -5,4 +5,4 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: self-hosted
     steps:
-      - run: $Env:Path
+      - run: zstd

--- a/.github/workflows/testAction.yml
+++ b/.github/workflows/testAction.yml
@@ -1,32 +1,8 @@
 name: Test
 run-name: Testing
-on: [push]
+on: [workflow_dispatch]
 jobs:
   Explore-GitHub-Actions:
     runs-on: self-hosted
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        
-      - name: Cache Unity files
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}\Library
-          key: unity-library
-          
-      - name: Make Library folder
-        run: mkdir Library; echo foo | Out-File Library/foo.txt
-          
-      #- name: Build Windows
-      #  shell: cmd
-      #  run: |
-      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
-          
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          # Artifact name
-          name: Some build # optional, default is artifact
-          # A file, directory or wildcard pattern that describes what to upload
-          path: ${{ github.workspace }}\Build\testbuild.exe
-          
+      - run: $Env:Path

--- a/.github/workflows/testAction.yml
+++ b/.github/workflows/testAction.yml
@@ -1,0 +1,32 @@
+name: Test
+run-name: Testing
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: self-hosted
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        
+      - name: Cache Unity files
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}\Library
+          key: unity-library
+          
+      - name: Make Library folder
+        run: mkdir Library; echo foo | Out-File Library/foo.txt
+          
+      #- name: Build Windows
+      #  shell: cmd
+      #  run: |
+      #    start "Build" /wait "c:\Program Files\Unity\Hub\Editor\2020.3.21f1\Editor\Unity.exe" -projectPath ${{ github.workspace }} -batchmode -buildWindowsPlayer ${{ github.workspace }}\Build\testbuild.exe -quit
+          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          # Artifact name
+          name: Some build # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: ${{ github.workspace }}\Build\testbuild.exe
+          

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.5
+  bundleVersion: 1.0.6
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.0
+  bundleVersion: 12.3.2
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 6.2.6
+  bundleVersion: 1.0.5
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 4.1.2
+  bundleVersion: 6.2.6
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.6.3
+  bundleVersion: 7.3.5
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 4.2.3
+  bundleVersion: 2.6.3
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 3.2.1
+  bundleVersion: 4.2.3
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 7.3.5
+  bundleVersion: 4.1.2
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 12.3.2
+  bundleVersion: 3.2.1
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/npm/getBinary.js
+++ b/npm/getBinary.js
@@ -9,7 +9,7 @@ function getBinary(){
 
     if (type !== 'Windows_NT') throw new Error(`Unsupported platform: Currently only for Windows`);
 
-    return new Binary("dcl-edit.exe",`https://github.com/metagamehub/dcl-edit/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
+    return new Binary("dcl-edit.exe",`https://github.com/cblech/dcl-edit-automation/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
 }
 
 module.exports = getBinary;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "3.2.1",
+  "version": "4.2.3",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dcl-edit",
-  "version": "1.0.0",
+  "version": "12.3.2",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" \u0026\u0026 exit 1",
     "postinstall": "node ./install.js",
     "preinstall": "node ./uninstall.js"
   },

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "4.1.2",
+  "version": "6.2.6",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "2.6.3",
+  "version": "7.3.5",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "7.3.5",
+  "version": "4.1.2",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "4.2.3",
+  "version": "2.6.3",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "6.2.6",
+  "version": "1.0.5",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcl-edit",
-  "version": "12.3.2",
+  "version": "3.2.1",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
To test this version, run: 
`npm install https://gitpkg.now.sh/{{ env.DCL_EDIT_REPO }}/npm?ref/feautre/release_version_{{ github.event.inputs.version }} -g` 

You still need to `npm publish` and merge this PR