### PR TITLE
Release of version 1.0.8

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.2
+  bundleVersion: 1.0.8
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/npm/getBinary.js
+++ b/npm/getBinary.js
@@ -9,7 +9,7 @@ function getBinary(){
 
     if (type !== 'Windows_NT') throw new Error(`Unsupported platform: Currently only for Windows`);
 
-    return new Binary("dcl-edit.exe",`https://github.com/metagamehub/dcl-edit/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
+    return new Binary("dcl-edit.exe",`https://github.com/cblech/dcl-edit-automation/releases/download/${version}/dcl-edit-${version}-windows-x86.tar.gz`)
 }
 
 module.exports = getBinary;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dcl-edit",
-  "version": "1.0.2",
+  "version": "1.0.8",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" \u0026\u0026 exit 1",
     "postinstall": "node ./install.js",
     "preinstall": "node ./uninstall.js"
   },


### PR DESCRIPTION
To test this version, run: 
`npm install https://gitpkg.now.sh/cblech/dcl-edit-automation/npm?ref/feautre/release_version_1.0.8 -g` 

You still need to `npm publish` and merge this PR