### PR TITLE
Release of version 1.0.18

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.11
+  bundleVersion: 1.0.18
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dcl-edit",
-  "version": "1.0.9",
+  "version": "1.0.18",
   "description": "A scene editor for the Decentraland SDK",
   "main": "./index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" \u0026\u0026 exit 1",
     "postinstall": "node ./install.js",
     "preinstall": "node ./uninstall.js"
   },


### PR DESCRIPTION
To test this version, run: 
`npm install https://gitpkg.now.sh/cblech/dcl-edit-automation/npm?ref/feautre/release_version_1.0.18 -g` 

You still need to `npm publish` and merge this PR